### PR TITLE
Added `tmux` as part of setup for long job management

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -81,3 +81,4 @@ USER root
 
 RUN apt update -qq && \
     apt install -y numactl
+    apt install -y tmux


### PR DESCRIPTION
Necessary for users to be able to run long jobs while away from container.